### PR TITLE
Add talent search

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -468,7 +468,7 @@ class DiscordBot(discord.Client):
             e = discord.Embed(title='Talent search')
             talents = [f'**{t["name"]}**: ({t["description"]})' for t in tree['talents']]
             e.add_field(name=f'__{tree["name"]}__', value='\n'.join(talents), inline=True)
-            e.add_field(name='Classes using this Talent Tree:', value=', '.join(tree['classes']), inline=False)
+            e.add_field(name='__Classes using this Talent Tree:__', value=', '.join(tree['classes']), inline=False)
         else:
             color = discord.Color.from_rgb(255, 255, 255)
             e = discord.Embed(title=f'Talent search for `{search_term}` found {len(result)} matches.', color=color)

--- a/team_expando.py
+++ b/team_expando.py
@@ -416,7 +416,7 @@ class TeamExpander:
                 self.translate_talent_tree(result, lang)
                 possible_matches.append(result)
             else:
-                talent_matches = [t for t in translated_talents if real_search in t]
+                talent_matches = [t for t in translated_talents if real_search in extract_search_tag(t)]
                 if talent_matches:
                     result = tree.copy()
                     result['talent_matches'] = talent_matches


### PR DESCRIPTION
Added talent search, capable of searching by talent tree or talent name.

In case where multiple results are found, shows the list including talent names if they are a match.
In case one result is found, currently always shows the whole tree, regardless if found by trait.

Styling could probably use more work.