### PR TITLE
fix: init subscriptions object if file not exist

### DIFF
--- a/subscriptions.py
+++ b/subscriptions.py
@@ -7,7 +7,7 @@ class Subscriptions:
     SUBSCRIPTION_CONFIG_FILE = 'subscriptions.json'
 
     def __init__(self):
-        self.subscriptions = None
+        self.subscriptions = {}
         self.load_subscriptions()
 
     def save_subscriptions(self):


### PR DESCRIPTION
On a clean new bot, if `subscriptions = None` all kind of stuff will break when you try to count subscriptions, add them etc. if the file does not exist, meaning it will never be created.