### PR TITLE
Added Tower of Doom tracking functionality

### DIFF
--- a/base_bot.py
+++ b/base_bot.py
@@ -60,6 +60,16 @@ class BaseBot(discord.Client):
             if not has_permission:
                 log.info(f'Missing permission {permission} in channel {message.guild} / {message.channel}.')
 
+    async def react(self, message, reaction: discord.Emoji):
+        if message.guild:
+            await self.check_for_needed_permissions(message)
+        try:
+            await message.add_reaction(emoji=reaction)
+        except discord.errors.Forbidden:
+            log.warning(f'[{message.guild}][{message.channel}] Could not post response, channel is forbidden for me.')
+        except EmbedLimitsExceed as e:
+            log.warning(f'[{message.guild}][{message.channel}] Could not post response, embed limits exceed: {e}.')
+
     async def answer(self, message, embed: discord.Embed):
         if message.guild:
             await self.check_for_needed_permissions(message)

--- a/bot.py
+++ b/bot.py
@@ -47,8 +47,8 @@ class DiscordBot(BaseBot):
     DEFAULT_PREFIX = '!'
     DEFAULT_LANGUAGE = 'en'
     BOT_NAME = 'garyatrics.com'
-    BASE_GUILD = "Eric's Test Server"
-    VERSION = '0.7'
+    BASE_GUILD = "Garyatrics"
+    VERSION = '0.6'
     GRAPHICS_URL = 'https://garyatrics.com/gow_assets'
     NEEDED_PERMISSIONS = [
         'add_reactions',
@@ -144,7 +144,7 @@ class DiscordBot(BaseBot):
         },
         {
             'function': 'edit_tower_floor',
-            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)tower (?P<floor>[^ ]+) (?P<scrollA>[^ ]+) (?P<scrollB>[^ ]+) (?P<scrollC>[^ ]+) (?P<scrollD>[^ ]+) ?(?P<scrollE>[^ ]+)?$', re.IGNORECASE)
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)tower (?P<floor>[^ ]+) (?P<scroll_ii>[^ ]+) (?P<scroll_iii>[^ ]+) (?P<scroll_iv>[^ ]+) (?P<scroll_v>[^ ]+) ?(?P<scroll_vi>[^ ]+)?$', re.IGNORECASE)
         },
         {
             'function': 'handle_team_code',
@@ -729,7 +729,7 @@ class DiscordBot(BaseBot):
             e.add_field(name='Success' if r[0] else 'Failure', value=r[1])
             await self.answer(message, e)
             
-    async def edit_tower_floor(self, message, lang, prefix, floor, scrollA, scrollB, scrollC, scrollD, scrollE = None):
+    async def edit_tower_floor(self, message, lang, prefix, floor, scroll_ii, scroll_iii, scroll_iv, scroll_v, scroll_vi = None):
         e = discord.Embed(title='Tower of Doom', color=self.WHITE)
 
         my_data = self.tower_data.get(message.guild)
@@ -737,18 +737,18 @@ class DiscordBot(BaseBot):
         short = my_data["short"]
 
         rA = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
-            message=message, floor=floor, room="II", scroll=scrollA)
+            message=message, floor=floor, room="II", scroll=scroll_ii)
         rB = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
-            message=message, floor=floor, room="III", scroll=scrollB)
+            message=message, floor=floor, room="III", scroll=scroll_iii)
         rC = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
-            message=message, floor=floor, room="IV", scroll=scrollC)
+            message=message, floor=floor, room="IV", scroll=scroll_iv)
         rD = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
-            message=message, floor=floor, room="V", scroll=scrollD)
+            message=message, floor=floor, room="V", scroll=scroll_v)
         # Mythic Room
-        if scrollE != None:
-            log.info(scrollE)
+        if scroll_vi != None:
+            log.info(scroll_vi)
             rE = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
-                message=message, floor=floor, room="VI", scroll=scrollE)
+                message=message, floor=floor, room="VI", scroll=scroll_vi)
         else:
             rE = (True, '')
 
@@ -765,7 +765,7 @@ class DiscordBot(BaseBot):
                 f"{'Success' if rB[0] else 'Failure'}: {rB[1]}",
                 f"{'Success' if rC[0] else 'Failure'}: {rC[1]}",
                 f"{'Success' if rD[0] else 'Failure'}: {rD[1]}",
-                f"{'Success' if rE[0] else 'Failure'}: {rE[1]}" if scrollE != None else ''
+                f"{'Success' if rE[0] else 'Failure'}: {rE[1]}" if scroll_vi != None else ''
             ])
 
             e.add_field(name='Edit Tower (Floor)', value=edit_text)

--- a/bot.py
+++ b/bot.py
@@ -11,16 +11,17 @@ from discord.ext import tasks
 
 from base_bot import BaseBot, log
 from game_constants import RARITY_COLORS
-from help import get_help_text
+from help import get_help_text, get_tower_help_text
 from jobs.news_downloader import NewsDownloader
 from language import Language
 from prefix import Prefix
 from subscriptions import Subscriptions
 from team_expando import TeamExpander
+from tower_data import TowerOfDoomData
 from translations import Translations
+from util import format_bool
 
 TOKEN = os.getenv('DISCORD_TOKEN')
-
 
 def chunks(iterable, chunk_size):
     for i in range(0, len(iterable), chunk_size):
@@ -46,8 +47,8 @@ class DiscordBot(BaseBot):
     DEFAULT_PREFIX = '!'
     DEFAULT_LANGUAGE = 'en'
     BOT_NAME = 'garyatrics.com'
-    BASE_GUILD = 'Garyatrics'
-    VERSION = '0.6'
+    BASE_GUILD = "Eric's Test Server"
+    VERSION = '0.7'
     GRAPHICS_URL = 'https://garyatrics.com/gow_assets'
     NEEDED_PERMISSIONS = [
         'add_reactions',
@@ -114,6 +115,38 @@ class DiscordBot(BaseBot):
             'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)prefix (?P<new_prefix>.+)$', re.IGNORECASE)
         },
         {
+            'function': 'show_tower_help',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)towerhelp$', re.IGNORECASE)
+        },
+        {
+            'function': 'show_tower_config',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)towerconfig$', re.IGNORECASE)
+        },
+        {
+            'function': 'set_tower_config_alias',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)towerconfig (?P<category>[^ ]+) (?P<field>[^ ]+) (?P<values>.+)$', re.IGNORECASE)
+        },
+        {
+            'function': 'set_tower_config_option',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)towerconfig (?P<option>[^ ]+) (?P<value>.+)$', re.IGNORECASE)
+        },
+        {
+            'function': 'show_tower_data',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)tower$', re.IGNORECASE)
+        },
+                {
+            'function': 'clear_tower_data',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)towerclear$', re.IGNORECASE)
+        },
+        {
+            'function': 'edit_tower_single',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)tower (?P<floor>[^ ]+) (?P<room>[^ ]+) (?P<scroll>[^ ]+)$', re.IGNORECASE)
+        },
+        {
+            'function': 'edit_tower_floor',
+            'pattern': re.compile(r'^' + LANG_PATTERN + r'(?P<prefix>.)tower (?P<floor>[^ ]+) (?P<scrollA>[^ ]+) (?P<scrollB>[^ ]+) (?P<scrollC>[^ ]+) (?P<scrollD>[^ ]+) ?(?P<scrollE>[^ ]+)?$', re.IGNORECASE)
+        },
+        {
             'function': 'handle_team_code',
             'pattern': re.compile(
                 r'.*?' + LANG_PATTERN + r'(?P<shortened>-)?\[(?P<team_code>(\d+,?){1,13})\].*',
@@ -151,6 +184,7 @@ class DiscordBot(BaseBot):
         log.debug(f'--------------------------- Starting {self.BOT_NAME} v{self.VERSION} --------------------------')
 
         self.expander = TeamExpander()
+        self.tower_data = TowerOfDoomData()
         self.prefix = Prefix(self.DEFAULT_PREFIX)
         self.language = Language(self.DEFAULT_LANGUAGE)
         self.subscriptions = Subscriptions()
@@ -243,6 +277,21 @@ class DiscordBot(BaseBot):
         e = discord.Embed(title=help_title, color=self.WHITE)
         for section, text in help_text.items():
             e.add_field(name=section, value=text, inline=False)
+        await self.answer(message, e)
+
+    async def show_tower_help(self, message, prefix, lang):
+        help_title, help_text = get_tower_help_text(prefix, lang)
+
+        e = discord.Embed(title=help_title, color=self.WHITE)
+        for section, text in help_text.items():
+            e.add_field(name=section, value=text, inline=False)
+        await self.answer(message, e)
+
+    async def clear_tower_data(self, message, prefix, lang):
+        self.tower_data.clear_data(prefix, message.guild, message)
+
+        e = discord.Embed(title="Tower of Doom", color=self.WHITE)
+        e.add_field(name="Success", value=f"Cleared tower data for #{message.channel.name}", inline=False)
         await self.answer(message, e)
 
     async def show_quickhelp(self, message, prefix, lang):
@@ -628,6 +677,100 @@ class DiscordBot(BaseBot):
         e.add_field(name='The current prefix is', value=f'`{prefix}`')
         await self.answer(message, e)
 
+    async def show_tower_config(self, message, lang, prefix):
+        e = self.tower_data.format_output_config(prefix=prefix, guild=message.guild, color=self.WHITE)
+        await self.answer(message, e)
+
+    async def set_tower_config_option(self, message, lang, prefix, option, value):
+        if self.is_guild_admin(message):
+            old_value, new_value = self.tower_data.set_option(guild=message.guild, option=option, value=value)
+
+            e = discord.Embed(title='Administrative action', color=self.RED)
+            e.add_field(name='Tower change accepted', value=f'Option {option} changed from `{old_value}` to `{new_value}`')
+            await self.answer(message, e)
+            log.debug(f'[{message.guild.name}] Changed Tower config {option} from {old_value} to {new_value}')
+        else:
+            e = discord.Embed(title='Administrative action', color=self.RED)
+            e.add_field(name='Tower change rejected', value=f'Only admins can change config options.')
+            await self.answer(message, e)
+
+    async def set_tower_config_alias(self, message, lang, prefix, category, field, values):
+        if self.is_guild_admin(message):
+            old_values, new_values = self.tower_data.set_alias(guild=message.guild, category=category, field=field, values=values)
+
+            e = discord.Embed(title='Administrative action', color=self.RED)
+            e.add_field(name='Tower change accepted', value=f'Alias {category}: {field} was changed from `{old_values}` to `{new_values}`')
+            await self.answer(message, e)
+            log.debug(f'[{message.guild.name}] Changed Tower config {category}: {field} from {old_values} to {new_values}')
+        else:
+            e = discord.Embed(title='Administrative action', color=self.RED)
+            e.add_field(name='Tower change rejected', value=f'Only admins can change config options.')
+            await self.answer(message, e)
+
+    async def show_tower_data(self, message, lang, prefix):
+        e = self.tower_data.format_output(guild=message.guild, channel=message.channel,
+            color=self.WHITE)
+        await self.answer(message, e)
+
+    async def edit_tower_single(self, message, lang, prefix, floor, room, scroll):
+        my_data = self.tower_data.get(message.guild)
+
+        short = my_data["short"]
+        
+        r = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+            message=message, floor=floor, room=room, scroll=scroll)
+        
+        if short:
+            # Respond with a reaction.
+            await self.react(message, format_bool(r[0]))
+        else:
+            # Respond with an embed.
+            e = discord.Embed(title='Tower of Doom', color=self.WHITE)
+            e.add_field(name='Success' if r[0] else 'Failure', value=r[1])
+            await self.answer(message, e)
+            
+    async def edit_tower_floor(self, message, lang, prefix, floor, scrollA, scrollB, scrollC, scrollD, scrollE = None):
+        e = discord.Embed(title='Tower of Doom', color=self.WHITE)
+
+        my_data = self.tower_data.get(message.guild)
+
+        short = my_data["short"]
+
+        rA = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+            message=message, floor=floor, room="II", scroll=scrollA)
+        rB = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+            message=message, floor=floor, room="III", scroll=scrollB)
+        rC = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+            message=message, floor=floor, room="IV", scroll=scrollC)
+        rD = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+            message=message, floor=floor, room="V", scroll=scrollD)
+        # Mythic Room
+        if scrollE != None:
+            log.info(scrollE)
+            rE = self.tower_data.edit_floor(prefix=prefix, guild=message.guild,
+                message=message, floor=floor, room="VI", scroll=scrollE)
+        else:
+            rE = (True, '')
+
+        success = rA[0] and rB[0] and rC[0] and rD[0] and rE[0]
+
+        if short:
+            # This is a reaction.
+            await self.react(message, format_bool(success))
+        else:
+            # It's an embed.
+            e = discord.Embed(title='Tower of Doom', color=self.WHITE)
+            edit_text = '\n'.join([
+                f"{'Success' if rA[0] else 'Failure'}: {rA[1]}",
+                f"{'Success' if rB[0] else 'Failure'}: {rB[1]}",
+                f"{'Success' if rC[0] else 'Failure'}: {rC[1]}",
+                f"{'Success' if rD[0] else 'Failure'}: {rD[1]}",
+                f"{'Success' if rE[0] else 'Failure'}: {rE[1]}" if scrollE != None else ''
+            ])
+
+            e.add_field(name='Edit Tower (Floor)', value=edit_text)
+            await self.answer(message, e)
+
     async def news_subscribe(self, message, prefix):
         if not message.guild:
             return
@@ -759,4 +902,7 @@ async def test_task(discord_client):
 if __name__ == '__main__':
     client = DiscordBot()
     test_task.start(client)
-    client.run(TOKEN)
+    if TOKEN is not None:
+        client.run(TOKEN)
+    else:
+        log.error('FATAL ERROR: DISCORD_TOKEN env var was not specified.')

--- a/data_source/world_data.py
+++ b/data_source/world_data.py
@@ -10,12 +10,14 @@ class WorldData:
     def __init__(self):
         self.EVENT_TYPES = {
             0: '[GUILD_WARS]',
+            1: '[RAIDBOSS]',
             2: '[INVASION]',
             3: '[VAULT]',
             4: '[BOUNTY]',
             5: '[PETRESCUE]',
             6: '[CLASS_EVENT]',
             7: '[DELVE_EVENT]',
+            8: '[TOWER_OF_DOOM]',
             9: '[HIJACK]',
             10: '[ADVENTURE_BOARD_SPECIAL_EVENT]',
             11: '[CAMPAIGN]',
@@ -54,9 +56,8 @@ class WorldData:
     def read_json_data(self):
         with open('World.json') as f:
             self.data = json.load(f)
-        if os.path.exists('User.json'):
-            with open('User.json', encoding='utf8') as f:
-                self.user_data = json.load(f)
+        with open('User.json', encoding='utf8') as f:
+            self.user_data = json.load(f)
 
     def populate_world_data(self):
         self.read_json_data()

--- a/help.py
+++ b/help.py
@@ -159,7 +159,33 @@ help_texts = {
                           '• __Ayuda rápida__: Utilice {0}quickhelp para abrir una breve lista de todos los comandos.'
     },
 }
+tower_help_titles = {
+    'en': 'Tower of Doom Help',
+}
+tower_help_texts = {
+    'en': {
+        'Basics': 'Users can use the `{0}tower` command to enter Scroll data for the Tower of Doom,'
+                  'then display it for easy viewing. Each Tower is specific to the channel it is in.',
+        'Entering Data': 'To enter data, use the `{0}tower` command. Shortened names or aliases can be used.\n'
+                         '`{0}tower 4 ii unlock`\n'
+                         '`{0}tower 5 rare fi`\n'
+                         'You can set a whole floor in one line:\n'
+                         '`{0}tower 6 armor fireball unlock haste`\n',
+        'Displaying Data': 'To display the data, simply use the `{0}tower` command with no arguments.',
+        'Clearing Data': 'To clear the tower data, simply use the `{0}towerclear` command with no arguments.',
+        'Configuration': 'To configure the tower utility, use `{0}towerconfig`.\n'
+                         '`{0}towerconfig short true` for short responses to edits.\n'
+                         '`{0}towerconfig rooms III iii,r,rare,green` to set the room aliases. Comma separated values.\n'
+                         '`{0}towerconfig scrolls armor :shield:,ar,Armor` to set scroll aliases. First value will be used for display.\n',
 
+    }
+}
+
+
+def get_tower_help_text(prefix, lang):
+    tower_help_title = tower_help_titles.get(lang, tower_help_titles['en'])
+    tower_help_content = tower_help_texts.get(lang, tower_help_texts['en'])
+    return tower_help_title, {section: text.format(prefix) for section, text in tower_help_content.items()}
 
 def get_help_text(prefix, lang):
     help_title = help_titles.get(lang, help_titles['en'])

--- a/tower_data.py
+++ b/tower_data.py
@@ -1,0 +1,297 @@
+import discord
+import json
+import os
+import threading
+
+from base_bot import log
+from util import atoi, merge, natural_keys, format_bool
+
+class TowerOfDoomData:
+    TOWER_CONFIG_FILE = 'towerofdoom.json'
+
+    DEFAULT_TOWER_DATA = {
+        'rooms': {
+            "II": ["II", "r", "Rare"],
+            "III": ["III", "u", "ur", "ultrarare", "Ultra-Rare"],
+            "IV": ["IV", "e", "Epic"],
+            "V": ["V", "l", "Legendary"],
+            "VI": ["VI", "m", "Mythic"]
+        },
+        'scrolls': {
+            "armor": ["🛡️", "ar", "Armor"],
+            "attack": ["⚔️", "at", "Attack"],
+            "life": ["❤️", "li", "Life"],
+            "magic": ["🔮", "ma", "Magic"],
+            "haste": ["💨", "ha", "Haste"],
+            "luck": ["🍀", "lu", "Luck"],
+            "power": ["⚡", "po", "Power"],
+            "unlock": ["🆙", "un", "Unlock"],
+            "heroism": ["🦸", "he", "Heroism"],
+            "fireball": ["🔥", "fi", "Fireball"],
+            "unknown": ["❓", "?", "unknown"]
+        },
+        # Options.
+        "short": False,
+        "hide": [
+            "armor",
+            "attack",
+            "life",
+            "magic",
+            "power"
+        ],
+    }
+
+    def __init__(self):
+        self.__data = {}
+        self.load_data()
+
+    def load_data(self):
+        if not os.path.exists(self.TOWER_CONFIG_FILE):
+            return
+        lock = threading.Lock()
+        with lock:
+            with open(self.TOWER_CONFIG_FILE) as f:
+                self.__data = json.load(f)
+
+    def save_data(self):
+        lock = threading.Lock()
+        with lock:
+            with open(self.TOWER_CONFIG_FILE, 'w') as f:
+                json.dump(self.__data, f, sort_keys=True, indent=2)
+
+    def set(self, guild, data):
+        self.__data[str(guild.id)] = data
+        self.save_data()
+
+    def set_alias(self, guild, category, field, values):
+        # Bypass .get() since that includes default data.
+        my_data = self.__data.get(str(guild.id), {})
+
+        old_values = my_data.get(
+            category, self.DEFAULT_TOWER_DATA[category]
+        ).get(
+            field, self.DEFAULT_TOWER_DATA[category][field]
+        )
+        new_values = values.split(',')
+
+        # Create a dict if it doesn't exist
+        my_data[category] = my_data.get(category, {})
+        my_data[category][field] = new_values
+        self.set(guild, my_data)
+
+        return (', '.join(old_values), ', '.join(new_values))
+
+    def set_scroll(self, guild, channel, floor, room, scroll):
+        # Bypass .get() since that includes default data.
+        my_data = self.__data.get(str(guild.id), {})
+
+        # Create a dict if it doesn't exist
+        my_data[channel] = my_data.get(channel, {})
+        my_data[channel][floor] = my_data[channel].get(floor, {})
+        
+        old_value = my_data[channel][floor].get(room, 'unknown')
+        my_data[channel][floor][room] = scroll
+        new_value = my_data[channel][floor].get(room, '<ERROR>')
+        self.set(guild, my_data)
+
+        return (old_value, new_value)
+
+    def get(self, guild):
+        # TODO: Make sure the config returns defaults for any unpopulated values,
+        # while also avoiding writing defaults to save space.
+        # I use lots of .get(key, default) to avoid 
+        if guild is None:
+            return {}
+        return merge(dict(self.__data.get(str(guild.id), {})), self.DEFAULT_TOWER_DATA)
+
+    def clear_data(self, prefix, guild, message):
+        # Bypass .get() since that includes default data.
+        my_data = self.__data.get(str(guild.id), {})
+        channel = str(message.channel.id)
+
+        # Override channel data with empty.
+        my_data[channel] = {}
+        self.set(guild, my_data)
+
+    def get_key_from_alias(self, data, category, value):
+        keys = self.DEFAULT_TOWER_DATA[category].keys()
+
+        # Get the key from the alias.
+        result = list(filter(lambda key: value.lower() in [i.lower() for i in data[category].get(key, [])], keys))
+        return result[0]
+
+    def edit_floor(self, prefix, guild, message, floor, room, scroll):
+        # Returns tuple (Success, Message)
+
+        # Includes default and server-custom data.
+        my_data = self.get(guild)
+
+        channel = str(message.channel.id)
+
+        try:
+            floor_number = atoi(floor)
+        except:
+            log.warn(f"Couldn't find floor {floor} in {my_data['floors']}")
+            return f'Invalid floor {floor}'
+
+        try:
+            room_key = self.get_key_from_alias(my_data, 'rooms', room)
+            room_display = my_data['rooms'][room_key][0]
+        except KeyError:
+            log.warn(f"Couldn't find room {room} in {my_data['rooms']}")
+            return (False, f'Couldn\'t find room {room}')
+
+        # Mythic room below floor 25? always a scroll.
+        if floor_number <= 25 and room_key == "VI":
+            return (False, f'The boss room on floor {floor_number} always contains a Forge Scroll.')
+
+        try:
+            scroll_key = self.get_key_from_alias(my_data, 'scrolls', scroll)
+            # Store the floor data.
+            scroll_new_display = my_data["scrolls"][scroll_key][0]
+            #
+            # ACTUALLY SET THE DATA HERE.
+            #
+            scroll_old_key, scroll_new_key = self.set_scroll(guild, channel, floor, room_key, scroll_key)
+        except KeyError as e:
+            return (False, f'Couldn\'t find scroll {scroll}')
+
+        # Success!
+        if scroll_old_key == 'unknown':
+            return (True, f'Set floor {floor} room {room_display} to {scroll_new_display}')
+        else:
+            scroll_old_display = my_data["scrolls"][scroll_old_key][0]
+            return (True, f'Replaced floor {floor} room {room_display} to {scroll_new_display} (was {scroll_old_display})')
+
+    def format_floor(self, my_data, display, floor, floor_data):
+        rooms = [
+            f'{my_data["rooms"]["II"][0]}={my_data["scrolls"].get(floor_data.get("II", "unknown"))[0]}',
+            f'{my_data["rooms"]["III"][0]}={my_data["scrolls"].get(floor_data.get("III", "unknown"))[0]}',
+            f'{my_data["rooms"]["IV"][0]}={my_data["scrolls"].get(floor_data.get("IV", "unknown"))[0]}',
+            f'{my_data["rooms"]["V"][0]}={my_data["scrolls"].get(floor_data.get("V", "unknown"))[0]}',
+            f'{my_data["rooms"]["VI"][0]}={my_data["scrolls"].get(floor_data.get("VI", "unknown"))[0]}'
+        ]
+        if floor_data.get('II', 'unknown') in my_data['hide']:
+            rooms[0] = f"||{rooms[0]}||"
+        if floor_data.get('III', 'unknown') in my_data['hide']:
+            rooms[1] = f"||{rooms[1]}||"
+        if floor_data.get('IV', 'unknown') in my_data['hide']:
+            rooms[2] = f"||{rooms[2]}||"
+        if floor_data.get('V', 'unknown') in my_data['hide']:
+            rooms[3] = f"||{rooms[3]}||"
+        if floor_data.get('VI', 'unknown') in my_data['hide']:
+            rooms[4] = f"||{rooms[4]}||"
+
+        # Hide the boss room (always a scroll)
+        if int(floor) <= 25:
+            del rooms[4]
+
+        return ' '.join(rooms)
+
+    def format_output(self, guild, color, channel):
+        my_data = self.get(guild)
+
+        tower_data = my_data.get(str(channel.id), {}).items()
+
+        if len(tower_data) == 0:
+            e = discord.Embed(title='Tower of Doom', color=color)
+            e.add_field(name=f'Failure', value=f'Couldn\'t any data for #{channel.name}.\nPlease use `!towerhelp` for more info.')
+            return e
+
+        tower_data = sorted(tower_data, key=natural_keys)
+
+        # Get the display strings for rooms and scrolls.
+        display = {}
+        for key in my_data["rooms"].keys():
+            display[key] = my_data["rooms"][key][0]
+        for key in my_data["scrolls"].keys():
+            display[key] = my_data["scrolls"][key][0]
+
+        tower_text = '\n'.join([
+            f'Floor {floor}: {self.format_floor(my_data, display, floor, floor_data)}' for floor, floor_data in tower_data
+        ])
+
+        if tower_text == "":
+            e = discord.Embed(title='Tower of Doom', color=color)
+            e.add_field(name=f'Failure', value=f'Couldn\'t any data for #{channel.name}.\nPlease use `!towerhelp` for more info.')
+            return e
+
+        e = discord.Embed(title='Tower of Doom', color=color)
+        e.add_field(name=f'#{channel.name}', value=tower_text)
+        log.warn(e.fields)
+        return e
+
+    def set_option(self, guild, option, value, boolean=False):
+        # Bypass .get() since that includes default data.
+        my_data = self.__data.get(str(guild.id), {})
+
+        if option in ['short']:
+            # String to boolean.
+            value_parsed = value.lower() in ['true', '1', 't', 'y', 'yes']
+        elif option in ['hide']:
+            # String to list.
+            if value == "none":
+                value_parsed = []
+            else:
+                value_parsed = value.split(',')
+        else:
+            value_parsed = value
+            
+        old_value = my_data.get(option, self.DEFAULT_TOWER_DATA[option])
+        my_data[option] = value_parsed
+        new_value = my_data.get(option, '<ERROR>')
+        self.set(guild, my_data)
+
+        return (old_value, new_value)
+
+    def format_output_config(self, prefix, guild, color):
+        my_data = self.get(guild)
+        e = discord.Embed(title='Tower of Doom Config', color=color)
+
+        log.info(my_data)
+
+        help_text = '\n'.join([
+            "To configure the aliases, provide a category and a list of values separated by commas.",
+            f"`{prefix}towerconfig rooms rare r,rare,ii`"
+        ])
+
+        e.add_field(name='Help', value=help_text, inline=False)
+
+        rooms_text = '\n'.join([
+            f'Rare (II): {", ".join(my_data["rooms"]["II"])}',
+            f'Ultra-Rare (III): {", ".join(my_data["rooms"]["III"])}',
+            f'Epic (IV): {", ".join(my_data["rooms"]["IV"])}',
+            f'Legendary (V): {", ".join(my_data["rooms"]["V"])}',
+            f'Mythic (VI): {", ".join(my_data["rooms"]["VI"])}',
+        ])
+
+        e.add_field(name='Rooms', value=rooms_text, inline=True)
+
+        # TODO: Revise get() to make this cleaner.
+        log.info(my_data["scrolls"])
+        scrolls_text = '\n'.join([
+            f'Armor: {", ".join(my_data["scrolls"]["armor"])}',
+            f'Attack: {", ".join(my_data["scrolls"]["attack"])}',
+            f'Life: {", ".join(my_data["scrolls"]["life"])}',
+            f'Magic: {", ".join(my_data["scrolls"]["magic"])}',
+            f'Haste: {", ".join(my_data["scrolls"]["haste"])}',
+            f'Luck: {", ".join(my_data["scrolls"]["luck"])}',
+            f'Power: {", ".join(my_data["scrolls"]["power"])}',
+            f'Unlock: {", ".join(my_data["scrolls"]["unlock"])}',
+            f'Heroism: {", ".join(my_data["scrolls"]["heroism"])}',
+            f'Fireball: {", ".join(my_data["scrolls"]["fireball"])}'
+        ])
+
+        e.add_field(name='Scrolls', value=scrolls_text, inline=True)
+
+        options_text = '\n'.join([
+            f'**Short Format**: {format_bool(my_data["short"])}',
+            'Only respond to edits with a :thumbs_up: instead of a full message.',
+            f'**Hide Values**: {"None" if my_data["hide"] == [] else ",".join(my_data["hide"])}',
+            'Hide unimportant scrolls with spoilers.'
+        ])
+
+        e.add_field(name='Options', value=options_text, inline=False)
+
+        return e
+

--- a/util.py
+++ b/util.py
@@ -1,0 +1,39 @@
+import re
+
+def atoi(text):
+    return int(text) if text.isdigit() else text
+
+def format_bool(value):
+    return "✅" if value else "❌"
+
+def natural_keys(text):
+    '''
+    alist.sort(key=natural_keys) sorts in human order
+    http://nedbatchelder.com/blog/200712/human_sorting.html
+    (See Toothy's implementation in the comments)
+    '''
+    if type(text) in [tuple, list]:
+        # List.
+        return [ atoi(c) for c in re.split(r'(\d+)', text[0]) ]
+    else:
+        # String or bytes.
+        return [ atoi(c) for c in re.split(r'(\d+)', text) ]
+
+# https://stackoverflow.com/questions/7204805/how-to-merge-dictionaries-of-dictionaries
+def merge(a, b, path=None):
+    "merges b into a"
+    if path is None: path = []
+    for key in b:
+        if key in a:
+            if isinstance(a[key], dict) and isinstance(b[key], dict):
+                merge(a[key], b[key], path + [str(key)])
+            elif a[key] == b[key]:
+                pass # same leaf value
+            else:
+                # Use a for conflicts.
+                pass
+                # raise Exception('Conflict at %s' % '.'.join(path + [str(key)]))
+        else:
+            print(f"FILL: {key} : {b[key]}")
+            a[key] = b[key]
+    return a


### PR DESCRIPTION
I saw a lot of people looking for a tool to help them track Tower of Doom scrolls, so I created a function similar to the bot created by Chris for the Epic Housecasts Discord.

Scouters use commands to provide the bot information on what scrolls are where, then anyone can use the `!tower` command to display the current state of the tower. Once a new event starts, the tower can be cleared to start again.

I have made this function highly configurable. The annoying message that appears each command can be hidden, allowing the bot to instead confirm receipt of an entry with a reaction. Each room can be referred to with various aliases (the Rare room can be referred to with 'ii', 'r', or 'rare'), as can the scrolls (Unlock is 🆙, un, or unlock). These aliases can be reconfigured, and when displaying the tower, the first alias in the list is used for display. This, icons can be replaced as desired, different shortcuts can be created (single letter shortcuts), or language variations used, all at the GM's discretion.

By default, boons are hidden behind spoiler tags, to reduce emphasis and make it easier to see which rooms to clear at a glance. If   a GM wishes to show certain scrolls or hide other ones (maybe their guild likes power scrolls and dislikes haste scrolls) they can configure that as well.

Each tower is specific to a channel in a server. This allows multiple guilds in one guild network server to separate layouts for different guilds.

I'm really proud about how this turned out. Please review it and see if there are any areas that need improvement or bugs that need fixing.

[Demonstration A](https://www.youtube.com/watch?v=a58-zO2hYCs&feature=youtu.be)
[Demonstration B](https://www.youtube.com/watch?v=Y-zU9he9DuI&feature=youtu.be)

![vlcsnap-2020-08-04-01h05m57s131](https://user-images.githubusercontent.com/4635334/89256259-b5abef00-d5f1-11ea-913a-b9f2e3340ce5.png)
