### PR TITLE
skip Apoc and HoG kingdoms in filename search

### DIFF
--- a/data_source/game_data.py
+++ b/data_source/game_data.py
@@ -486,7 +486,8 @@ class GameData:
             if not match:
                 continue
             kingdom_filename = match.group("filebase")
-            troop_kingdom = next((k for k in self.kingdoms.values() if k['filename'] == kingdom_filename), None)
+            #skip Apocalypse (3034) and HoG (3042), because they share filename with Sin of Maraj and Guardians resp. and unlikely to get new troops
+            troop_kingdom = next((k for k in self.kingdoms.values() if k['filename'] == kingdom_filename and k['id'] not in [3034, 3042]), None)
             if troop_kingdom:
                 troop['kingdom'] = troop_kingdom
                 troop_kingdom['troop_ids'].append(troop_id)

--- a/data_source/game_data.py
+++ b/data_source/game_data.py
@@ -486,8 +486,9 @@ class GameData:
             if not match:
                 continue
             kingdom_filename = match.group("filebase")
-            #skip Apocalypse (3034) and HoG (3042), because they share filename with Sin of Maraj and Guardians resp. and unlikely to get new troops
-            troop_kingdom = next((k for k in self.kingdoms.values() if k['filename'] == kingdom_filename and k['id'] not in [3034, 3042]), None)
+            # Skip Apocalypse (3034) and HoG (3042), because they share filename with Sin of Maraj and Guardians resp. and are unlikely to get new troops
+            skip_kingdoms = [3034, 3042]
+            troop_kingdom = next((k for k in self.kingdoms.values() if k['filename'] == kingdom_filename and k['id'] not in skip_kingdoms), None)
             if troop_kingdom:
                 troop['kingdom'] = troop_kingdom
                 troop_kingdom['troop_ids'].append(troop_id)


### PR DESCRIPTION
Apocalypse [3034] and Sin of Maraj [3037] kingdoms share filebase 'K34', which makes Sin of Maraj troops not assigned to kingdom show as they are from Apocalypse (Guardians [3033] and Hall of Guardians [3042] also share filebase, but this is not a problem yet). 